### PR TITLE
Update GMObjC.podspec

### DIFF
--- a/GMObjC.podspec
+++ b/GMObjC.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.13'
 
-  s.dependency "GMOpenSSL", "~> 3.0.9"
+  s.dependency "GMOpenSSL", "~> 3.1.0"
 end


### PR DESCRIPTION
`3.0.9`没有配置`static_framework = true`会导致配置了`use_frameworks!`的工程`pod install`报错`[!] The 'Pods-test' target has transitive dependencies that include statically linked binaries: (/Users/user/test/Pods/GMOpenSSL/Frameworks/OpenSSL.xcframework)`